### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,7 +176,7 @@ ECDSA.prototype.verify = function verify(message, signature, format = 'base64') 
   const verify = crypto.createVerify('RSA-SHA256') // RSA works with EC keys, too
   verify.write(message)
   verify.end()
-  const key = this.isPrivate ? this.asPublicECDSA() : this
+  const key = this.isPrivate ? this.asPublic() : this
   const signatureBuffer = Buffer.from(signature, format)
   return verify.verify(
     key.toPEM(),


### PR DESCRIPTION
There was a call being made to a asPublicECDSA method in verify which doesn't exist. asPublic was probably what was intended.